### PR TITLE
fix: infinite loop in dashboard data cache and contributor delete

### DIFF
--- a/src/components/contributor/contributorCard.tsx
+++ b/src/components/contributor/contributorCard.tsx
@@ -35,6 +35,7 @@ type ContributorCardProps = {
   isLeader?: boolean;
   isContact?: boolean;
   isConfluxUser?: boolean;
+  canDelete?: boolean;
   editMode: boolean;
   onEdit?: () => void;
   onDelete?: () => void;
@@ -50,7 +51,7 @@ export default function ContributorCard({
   position,
   isLeader,
   isContact,
-  isConfluxUser = false,
+  canDelete = false,
   editMode,
   onEdit,
   onDelete,
@@ -143,7 +144,7 @@ export default function ContributorCard({
                   </Tooltip>
                 </TooltipProvider>
 
-                {!isConfluxUser && (
+                {canDelete && (
                   <AlertDialog>
                     <TooltipProvider>
                       <Tooltip>

--- a/src/components/contributor/projectContributors.tsx
+++ b/src/components/contributor/projectContributors.tsx
@@ -53,6 +53,36 @@ export default function ProjectContributors({
     useState<ContributorResponseDTO | null>(null);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
+  // Check if a contributor can be deleted
+  // Can delete if:
+  // 1. No user is attached to the contributor, OR
+  // 2. User is attached but no longer has the contributor role
+  const canDeleteContributor = (
+    contributor: ContributorResponseDTO,
+  ): boolean => {
+    // Can always delete if no user is attached
+    if (!contributor.person.user_id) {
+      return true;
+    }
+
+    // Find the user in the project's users list
+    const attachedUser = project.users?.find(
+      (user) => user.id === contributor.person.user_id,
+    );
+
+    // If user not found in project, allow deletion (shouldn't happen but safe fallback)
+    if (!attachedUser) {
+      return true;
+    }
+
+    // Check if user still has contributor role
+    const hasContributorRole =
+      attachedUser.roles?.some((role) => role.type === "Contributor") ?? false;
+
+    // Can delete if user no longer has contributor role
+    return !hasContributorRole;
+  };
+
   const toggleEditMode = () => setEditMode(!editMode);
 
   const handleEditContributor = (contributor: ContributorResponseDTO) => {
@@ -133,6 +163,7 @@ export default function ProjectContributors({
                   contributor.positions.find((p) => !p.end_date)?.position
                 }
                 isConfluxUser={!!contributor.person.user_id}
+                canDelete={canDeleteContributor(contributor)}
                 isLeader={contributor.leader}
                 isContact={contributor.contact}
                 editMode={editMode}
@@ -159,10 +190,17 @@ export default function ProjectContributors({
                     </AlertDialogTitle>
                     <AlertDialogDescription>
                       <strong>
-                        In most cases you should end the users position to
+                        In most cases you should end the user's position to
                         signify their departure from the project
                       </strong>
                       <br />
+                      {contributor.person.user_id ? (
+                        <>
+                          This contributor is linked to a user account but no
+                          longer has the contributor role.
+                          <br />
+                        </>
+                      ) : null}
                       This will remove {contributor.person.name} from this
                       project and from any future syncs with RAiD. This action
                       cannot be undone.

--- a/src/hooks/useDashboardData.tsx
+++ b/src/hooks/useDashboardData.tsx
@@ -4,7 +4,7 @@
  * © Copyright Utrecht University (Department of Information and Computing Sciences)
  */
 
-import { useState, useEffect, useContext } from "react";
+import { useState, useEffect, useContext, useRef } from "react";
 import { ApiClientContext } from "@/lib/ApiClientContext";
 import {
   SwaggerException,
@@ -15,6 +15,11 @@ import { useProjectCache } from "@/hooks/useProjectCache";
 export function useDashboardData() {
   const apiClient = useContext(ApiClientContext);
   const projectCache = useProjectCache();
+  const projectCacheRef = useRef(projectCache);
+
+  // Update ref when projectCache changes
+  projectCacheRef.current = projectCache;
+
   const [data, setData] = useState<ProjectResponseDTO[] | undefined>();
   const [isLoading, setIsLoading] = useState(true);
   const [isInitialLoad, setIsInitialLoad] = useState(true);
@@ -25,7 +30,7 @@ export function useDashboardData() {
 
     const fetchData = async () => {
       // Check for cached data first
-      const cachedData = projectCache.getCachedDashboardData();
+      const cachedData = projectCacheRef.current.getCachedDashboardData();
       if (cachedData) {
         // Use cached data immediately for instant display
         if (isMounted) {
@@ -41,7 +46,7 @@ export function useDashboardData() {
           if (isMounted) {
             setData(freshData);
             // Update cache with fresh data
-            projectCache.setCachedDashboardData(freshData);
+            projectCacheRef.current.setCachedDashboardData(freshData);
           }
         } catch (err) {
           // If background update fails, just log it - we already have cached data showing
@@ -58,7 +63,7 @@ export function useDashboardData() {
           setData(result);
           setError(null);
           // Cache the fresh data
-          projectCache.setCachedDashboardData(result);
+          projectCacheRef.current.setCachedDashboardData(result);
         }
       } catch (err) {
         if (isMounted) {
@@ -88,7 +93,7 @@ export function useDashboardData() {
     return () => {
       isMounted = false;
     };
-  }, [apiClient, projectCache]);
+  }, [apiClient]);
 
   return { data, isLoading, isInitialLoad, error };
 }


### PR DESCRIPTION
## Description
- Fix infinite loop in dashboard data cache revalidation
- You can now delete a contributor with a user attached if that user no longer has the contributor role.

## Definition of done

Let's make sure we don't forget anything!
Please review the following list and check the boxes that apply to this PR.

If something is not applicable, please check the box anyway.
If something is not possible, please leave a comment explaining why.

- [x] Code is formatted using `npm run format`
- [x] Code satisfies requirement as currently specified in YouTrack
- [x] The not-so-happy flow and errors are handled gracefully
- [x] Models builds without errors and warnings
- [x] Any decisions or changes to the requirements have been added to the task description in YouTrack
- [x] Code is well-commented
- [x] (Manually) Tested UI on desktop, tablet and mobile screen sizes
  - UI is compatible for screens with a minimum of 340px of width
- [x] (Manually) Tested if changes might have unintended results for various browsers
  - [x] Chrome (or Chromium-based browsers)
  - [x] (Safari)
  - [x] Firefox
